### PR TITLE
Follow up #50

### DIFF
--- a/tools/profiletool_core.py
+++ b/tools/profiletool_core.py
@@ -290,12 +290,10 @@ class ProfileToolCore(QWidget):
         self.clearProfil()
         if self.toolrenderer:
             self.toolrenderer.cleaning()
-            try:
-                self.instance.layersRemoved.connect(
-                    lambda: self.removeClosedLayers(self.dockwidget.mdl)
-                )
-            except:
-                pass
+        try:
+            self.instance.layersRemoved.disconnect()
+        except:
+            pass
 
 
     #******************************************************************************************

--- a/ui/ptdockwidget.py
+++ b/ui/ptdockwidget.py
@@ -553,6 +553,7 @@ class PTDockWidget(QDockWidget, FormClass):
 
     def closeEvent(self, event):
         self.closed.emit()
+        self.profiletoolcore.cleaning()
         #self.butSaveAs.clicked.disconnect(self.saveAs)
         #return QDockWidget.closeEvent(self, event)
 


### PR DESCRIPTION
A python warning is raised after dockwidget was closed when removing from qgis layer tree a layer that was added to profiltool and not removed.