### PR TITLE
small fix to solve - 'unexpected type 'numpy.float64' - on setValue.

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -379,7 +379,7 @@ class PlotItem(GraphicsWidget):
             self.ctrl.yGridCheck.setChecked(y)
         if alpha is not None:
             v = np.clip(alpha, 0, 1)*self.ctrl.gridAlphaSlider.maximum()
-            self.ctrl.gridAlphaSlider.setValue(v)
+            self.ctrl.gridAlphaSlider.setValue( int(v) )
         
     def close(self):
         ## Most of this crap is needed to avoid PySide trouble. 


### PR DESCRIPTION
It would be probably better to upgrade the whole pyqtgraph to the latest versions, but of course more dangerous. 
On my system (linux, python 3.10, qgis 3.22.3) profile tool was failing on button click with the error:

```
TypeError: setValue(self, int): argument 1 has unexpected type 'numpy.float64' 
Traceback (most recent call last):
  File "/home/luca/.local/share/QGIS/QGIS3/profiles/default/python/plugins/profiletool/profileplugin.py", line 88, in run
    self.profiletool = ProfileToolCore(self.iface, self)
  File "/home/luca/.local/share/QGIS/QGIS3/profiles/default/python/plugins/profiletool/tools/profiletool_core.py", line 99, in __init__
    self.dockwidget.changePlotLibrary(self.dockwidget.cboLibrary.currentIndex())
  File "/home/luca/.local/share/QGIS/QGIS3/profiles/default/python/plugins/profiletool/ui/ptdockwidget.py", line 143, in changePlotLibrary
    self.addPlotWidget(self.plotlibrary)
  File "/home/luca/.local/share/QGIS/QGIS3/profiles/default/python/plugins/profiletool/ui/ptdockwidget.py", line 177, in addPlotWidget
    self.plotWdg = PlottingTool().changePlotWidget("PyQtGraph", self.frame_for_plot)
  File "/home/luca/.local/share/QGIS/QGIS3/profiles/default/python/plugins/profiletool/tools/plottingtool.py", line 96, in changePlotWidget
    plotWdg.showGrid(True, True, 0.5)
  File "/home/luca/.local/share/QGIS/QGIS3/profiles/default/python/plugins/profiletool/pyqtgraph/graphicsItems/PlotItem/PlotItem.py", line 382, in showGrid
    self.ctrl.gridAlphaSlider.setValue(v)
TypeError: setValue(self, int): argument 1 has unexpected type 'numpy.float64'
```

By checking pyqtgraph repo seems like they also adopted this change:
https://github.com/pyqtgraph/pyqtgraph/blob/8279a0adb8954a21d5285e0a579d8101e01a6e45/pyqtgraph/graphicsItems/PlotItem/PlotItem.py#L382

thank you for maintaining profile tool.
best,
luca