### PR TITLE
Fix remaining Qt ItemDataRole usage for QGIS 4 compatibility

### DIFF
--- a/tools/tableviewtool.py
+++ b/tools/tableviewtool.py
@@ -45,7 +45,7 @@ class TableViewTool(QObject):
                 layer = iface.mapCanvas().layer(i)
                 if isProfilable(layer):
                     for j in range(0, mdl.rowCount()):
-                        if str(mdl.item(j, 2).data(Qt.UserRole.EditRole)) == str(layer.name()):
+                        if str(mdl.item(j, 2).data(Qt.ItemDataRole.EditRole)) == str(layer.name()):
                             donothing = True
                 else:
                     donothing = True
@@ -231,7 +231,7 @@ class TableViewTool(QObject):
                 mdl.item(index1.row(), 2).data(Qt.ItemDataRole.EditRole),
                 mdl.item(index1.row(), 3).data(Qt.ItemDataRole.EditRole),
             )
-            color = QColorDialog().getColor(temp.data(Qt.BackgroundRole))
+            color = QColorDialog().getColor(temp.data(Qt.ItemDataRole.BackgroundRole))
             mdl.setData(
                 mdl.index(temp.row(), 1, QModelIndex()), color, Qt.ItemDataRole.BackgroundRole
             )
@@ -242,7 +242,7 @@ class TableViewTool(QObject):
                 mdl.item(index1.row(), 2).data(Qt.ItemDataRole.EditRole),
                 mdl.item(index1.row(), 3).data(Qt.ItemDataRole.EditRole),
             )
-            booltemp = temp.data(Qt.CheckStateRole)
+            booltemp = temp.data(Qt.ItemDataRole.CheckStateRole)
             if booltemp is True:
                 booltemp = False
             else:

--- a/ui/ptdockwidget.py
+++ b/ui/ptdockwidget.py
@@ -176,7 +176,7 @@ class PTDockWidget(QDockWidget, FormClass):
             self.cbSameAxisScale.setCheckState(Qt.CheckState.Unchecked)
 
         else:
-            self.checkBox_mpl_tracking.setCheckState(0)
+            self.checkBox_mpl_tracking.setCheckState(Qt.CheckState.Unchecked)
             self.checkBox_mpl_tracking.setEnabled(False)
             self.cbSameAxisScale.setCheckState(Qt.CheckState.Unchecked)
 
@@ -345,7 +345,7 @@ class PTDockWidget(QDockWidget, FormClass):
         if (
             not self.mdl.item(item.row(), 5) is None
             and item.column() == 4
-            and self.mdl.item(item.row(), 5).data(Qt.EditRole).type()
+            and self.mdl.item(item.row(), 5).data(Qt.ItemDataRole.EditRole).type()
             == QgsMapLayer.LayerType.VectorLayer
         ):
 


### PR DESCRIPTION
Error when trying to change a chart line colour in QGIS4 when clicking the colour box next to a layer name.

This fixes remaining Qt role enum usages that still referenced pre-Qt6 names and caused crashes in QGIS 4.

In particular, clicking profile table cells could raise:

- `AttributeError: type object 'Qt' has no attribute 'CheckStateRole'`
- `AttributeError: type object 'Qt' has no attribute 'BackgroundRole'`

## Changes

- Replace `Qt.BackgroundRole` with `Qt.ItemDataRole.BackgroundRole`
- Replace `Qt.CheckStateRole` with `Qt.ItemDataRole.CheckStateRole`
- Replace a remaining `Qt.EditRole` access with `Qt.ItemDataRole.EditRole`
- Replace `setCheckState(0)` with `setCheckState(Qt.CheckState.Unchecked)`
- Fix one incorrect `Qt.UserRole.EditRole` usage to `Qt.ItemDataRole.EditRole`

## Error Log from QGIS

2026-03-19T12:24:45     WARNING    Traceback (most recent call last):
              File "C:\Users//AppData/Roaming/QGIS/QGIS4\profiles\default/python/plugins\profiletool\ui\ptdockwidget.py", line 340, in _onClick
              self.tableViewTool.onClick(self.iface, self, self.mdl, self.plotlibrary, index1)
              File "C:\Users//AppData/Roaming/QGIS/QGIS4\profiles\default/python/plugins\profiletool\tools\tableviewtool.py", line 245, in onClick
              booltemp = temp.data(Qt.CheckStateRole)
              ^^^^^^^^^^^^^^^^^
             AttributeError: type object 'Qt' has no attribute 'CheckStateRole'. Did you mean: 'CheckState'?

2026-03-19T12:26:57     WARNING    Traceback (most recent call last):
              File "C:\Users//AppData/Roaming/QGIS/QGIS4\profiles\default/python/plugins\profiletool\ui\ptdockwidget.py", line 340, in _onClick
              self.tableViewTool.onClick(self.iface, self, self.mdl, self.plotlibrary, index1)
              File "C:\Users//AppData/Roaming/QGIS/QGIS4\profiles\default/python/plugins\profiletool\tools\tableviewtool.py", line 234, in onClick
              color = QColorDialog().getColor(temp.data(Qt.BackgroundRole))
              ^^^^^^^^^^^^^^^^^
             AttributeError: type object 'Qt' has no attribute 'BackgroundRole'